### PR TITLE
Changes name to Infinite Red 2016 when using as boilerplate

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -79,7 +79,7 @@ async function install (context) {
 
   const name = parameters.third
   const spinner = print
-    .spin(`using the ${print.colors.red('Infinite Red')} boilerplate`)
+    .spin(`using the ${print.colors.red('Infinite Red 2016')} boilerplate`)
     .succeed()
 
   // attempt to install React Native or die trying


### PR DESCRIPTION
While spinning up a new app, I noticed that this boilerplate is called the "Infinite Red" boilerplate. This minor tweak changes it to "Infinite Red 2016" boilerplate.

<img width="397" alt="screen shot 2017-03-22 at 10 39 20 pm" src="https://cloud.githubusercontent.com/assets/1479215/24233578/66ffbfbe-0f50-11e7-93f1-e1328a88a9c3.png">
