### PR TITLE
pass pre-commit hooks when translation enabled

### DIFF
--- a/boilerplate.js
+++ b/boilerplate.js
@@ -103,10 +103,12 @@ async function install (context) {
   spinner.text = '▸ copying files'
   spinner.start()
   filesystem.copy(`${__dirname}/boilerplate/App`, `${process.cwd()}/App`, {
-    overwrite: true
+    overwrite: true,
+    matching: '!*.ejs'
   })
   filesystem.copy(`${__dirname}/boilerplate/Tests`, `${process.cwd()}/Tests`, {
-    overwrite: true
+    overwrite: true,
+    matching: '!*.ejs'
   })
   spinner.stop()
 

--- a/boilerplate.js
+++ b/boilerplate.js
@@ -82,6 +82,16 @@ async function install (context) {
     .spin(`using the ${print.colors.red('Infinite Red')} boilerplate`)
     .succeed()
 
+  // --max, --min, interactive
+  let answers
+  if (parameters.options.max) {
+    answers = options.answers.max
+  } else if (parameters.options.min) {
+    answers = options.answers.min
+  } else {
+    answers = await prompt.ask(options.questions)
+  }
+
   // attempt to install React Native or die trying
   const rnInstall = await reactNative.install({ name, skipJest: true })
   if (rnInstall.exitCode > 0) process.exit(rnInstall.exitCode)
@@ -111,12 +121,19 @@ async function install (context) {
     {
       template: 'App/Config/AppConfig.js.ejs',
       target: 'App/Config/AppConfig.js'
+    },
+    {
+      template: 'Tests/Setup.js.ejs',
+      target: 'Tests/Setup.js'
     }
   ]
   const templateProps = {
     name,
     igniteVersion: ignite.version,
-    reactNativeVersion: rnInstall.version
+    reactNativeVersion: rnInstall.version,
+    vectorIcons: answers['vector-icons'],
+    animatable: answers['animatable'],
+    i18n: answers['i18n']
   }
   await ignite.copyBatch(context, templates, templateProps, {
     quiet: true,
@@ -167,16 +184,6 @@ async function install (context) {
   await mergePackageJsons()
 
   spinner.stop()
-
-  // --max, --min, interactive
-  let answers
-  if (parameters.options.max) {
-    answers = options.answers.max
-  } else if (parameters.options.min) {
-    answers = options.answers.min
-  } else {
-    answers = await prompt.ask(options.questions)
-  }
 
   spinner.text = '▸ installing ignite dependencies'
   spinner.start()

--- a/boilerplate/Tests/Setup.js.ejs
+++ b/boilerplate/Tests/Setup.js.ejs
@@ -2,8 +2,8 @@ import mockery from 'mockery'
 import m from 'module'
 <%_ if (props.i18n === 'react-native-i18n') { _%>
 import english from '../App/I18n/languages/english.json'
-<%_ } _%>
 import {keys, replace, forEach} from 'ramda'
+<%_ } _%>
 
 // inject __DEV__ as it is not available when running through the tests
 global.__DEV__ = true

--- a/boilerplate/Tests/Setup.js.ejs
+++ b/boilerplate/Tests/Setup.js.ejs
@@ -1,6 +1,8 @@
 import mockery from 'mockery'
 import m from 'module'
+<%_ if (props.i18n === 'react-native-i18n') { _%>
 import english from '../App/I18n/languages/english.json'
+<%_ } _%>
 import {keys, replace, forEach} from 'ramda'
 
 // inject __DEV__ as it is not available when running through the tests
@@ -19,10 +21,15 @@ mockery.warnOnUnregistered(false)
 mockery.registerMock('reactotron-react-native', {})
 mockery.registerMock('reactotron-redux', {})
 mockery.registerMock('reactotron-apisauce', {})
+<%_ if (props.animatable === 'react-native-animatable') { _%>
 mockery.registerMock('react-native-animatable', {View: 'Animatable.View'})
+<%_ } _%>
+<%_ if (props.vectorIcons === 'react-native-vector-icons') { _%>
 mockery.registerMock('react-native-vector-icons/Ionicons', {})
+<%_ } _%>
 mockery.registerMock('react-native-router-flux', {Actions: {'myScreen': () => {}}, ActionConst: {RESET: 'reset'}})
 
+<%_ if (props.i18n === 'react-native-i18n') { _%>
 // Mock i18n as it uses react native stuff
 // This mock returns the interpolated text from the english.json file in App/I18n
 // If you are not using '../App/I18n/english.json' for your I18n values, simply replace import english
@@ -40,7 +47,7 @@ mockery.registerMock('react-native-i18n', {
     return value
   }
 })
-
+<%_ } _%>
 // Mock all images for React Native
 const originalLoader = m._load
 m._load = (request, parent, isMain) => {


### PR DESCRIPTION
 - Moves prompts to before generation
 - Passes prompt answers as props to templates
 - Adds ejs conditions to Tests/Setup.js 
 - Changes copy method to ignore ejs files

Fixes https://github.com/infinitered/ignite/issues/911