### PR TITLE
fix fonts in ApplicationStyles & Sagas import

### DIFF
--- a/boilerplate/App/Containers/Styles/LaunchScreenStyles.js
+++ b/boilerplate/App/Containers/Styles/LaunchScreenStyles.js
@@ -3,6 +3,9 @@ import { Metrics, ApplicationStyles } from '../../Themes/'
 
 export default StyleSheet.create({
   ...ApplicationStyles.screen,
+  container: {
+    paddingBottom: Metrics.baseMargin
+  },
   logo: {
     marginTop: Metrics.doubleSection,
     height: Metrics.images.logo,

--- a/boilerplate/App/Sagas/index.js
+++ b/boilerplate/App/Sagas/index.js
@@ -1,4 +1,4 @@
-import { takeLatest } from 'redux-saga'
+import { takeLatest } from 'redux-saga/effects'
 import API from '../Services/Api'
 import FixtureAPI from '../Services/FixtureApi'
 import DebugConfig from '../Config/DebugConfig'

--- a/boilerplate/App/Themes/ApplicationStyles.js
+++ b/boilerplate/App/Themes/ApplicationStyles.js
@@ -28,7 +28,7 @@ const ApplicationStyles = {
       padding: Metrics.baseMargin
     },
     sectionText: {
-      ...Fonts.normal,
+      ...Fonts.style.normal,
       paddingVertical: Metrics.doubleBaseMargin,
       color: Colors.snow,
       marginVertical: Metrics.smallMargin,


### PR DESCRIPTION
![screen shot 2017-03-23 at 10 47 04 am](https://cloud.githubusercontent.com/assets/144869/24262409/24df11c2-0fb7-11e7-8566-5f73ee64c2dd.png)

Fixed broken Fonts reference in App/Themes/ApplicationStyles.js so the correct font is applied to the Launch Screen. I also updated the LaunchScreenStyles.js so the 'OPEN DEVSCREENS' button is not flush with the bottom of the LaunchScreen

Fixed the { takeLastest } import statement in App/Sagas/index.js so the import is from 'redux-saga/effects' rather than just 'redux/saga', which results in runtime errors reported in Xcode. See `https://github.com/redux-saga/redux-saga#sagasjs` to see why 'takeLatest' should be imported from 'redux-saga/effects' rather than from 'redux-saga'