### PR TITLE
Fixes integration tests by taming execa.

### DIFF
--- a/test/generators-integration.test.js
+++ b/test/generators-integration.test.js
@@ -1,77 +1,74 @@
 const test = require('ava')
 const execa = require('execa')
 const jetpack = require('fs-jetpack')
-const path = require('path')
 
 const IGNITE = 'ignite'
 const APP = 'IntegrationTest'
 
 test.before(async t => {
   jetpack.remove(APP)
-  await execa(IGNITE, ['new', APP, '--min', '--skip-git', `--boilerplate=${__dirname}/../`], { env: { 'IGNITE_PLUGIN_PATH': path.resolve('../') } })
+  await execa(IGNITE, ['new', APP, '--min', '--skip-git', '--boilerplate', `${__dirname}/..`])
   process.chdir(APP)
-  // for some  reason... add it again (TODO: WTF)
-  await execa(IGNITE, ['add', '../'])
 })
 
 test('generates a component', async t => {
-  await execa(IGNITE, ['g', 'component', 'Test'])
-  t.truthy(jetpack.exists('App/Components/Test.js'))
-  t.truthy(jetpack.exists('App/Components/Styles/TestStyle.js'))
+  await execa(IGNITE, ['g', 'component', 'Test'], { preferLocal: false })
+  t.is(jetpack.exists('App/Components/Test.js'), 'file')
+  t.is(jetpack.exists('App/Components/Styles/TestStyle.js'), 'file')
   const lint = await execa('npm', ['-s', 'run', 'lint'])
   t.is(lint.stderr, '')
 })
 
 test('generate listview of type row works', async t => {
-  await execa(IGNITE, ['g', 'listview', 'TestRow', '--type=Row'])
-  t.truthy(jetpack.exists('App/Containers/TestRow.js'))
-  t.truthy(jetpack.exists('App/Containers/Styles/TestRowStyle.js'))
+  await execa(IGNITE, ['g', 'listview', 'TestRow', '--type=Row'], { preferLocal: false })
+  t.is(jetpack.exists('App/Containers/TestRow.js'), 'file')
+  t.is(jetpack.exists('App/Containers/Styles/TestRowStyle.js'), 'file')
   const lint = await execa('npm', ['run', 'lint'])
   t.is(lint.stderr, '')
 })
 
 test('generate listview of type sections works', async t => {
-  await execa(IGNITE, ['g', 'listview', 'TestSection', '--type=WithSections'])
-  t.truthy(jetpack.exists('App/Containers/TestSection.js'))
-  t.truthy(jetpack.exists('App/Containers/Styles/TestSectionStyle.js'))
+  await execa(IGNITE, ['g', 'listview', 'TestSection', '--type=WithSections'], { preferLocal: false })
+  t.is(jetpack.exists('App/Containers/TestSection.js'), 'file')
+  t.is(jetpack.exists('App/Containers/Styles/TestSectionStyle.js'), 'file')
   const lint = await execa('npm', ['run', 'lint'])
   t.is(lint.stderr, '')
 })
 
 test('generate listview of type grid works', async t => {
-  await execa(IGNITE, ['g', 'listview', 'TestGrid', '--type=Grid'])
-  t.truthy(jetpack.exists('App/Containers/TestGrid.js'))
-  t.truthy(jetpack.exists('App/Containers/Styles/TestGridStyle.js'))
+  await execa(IGNITE, ['g', 'listview', 'TestGrid', '--type=Grid'], { preferLocal: false })
+  t.is(jetpack.exists('App/Containers/TestGrid.js'), 'file')
+  t.is(jetpack.exists('App/Containers/Styles/TestGridStyle.js'), 'file')
   const lint = await execa('npm', ['run', 'lint'])
   t.is(lint.stderr, '')
 })
 
 test('generate redux works', async t => {
-  await execa(IGNITE, ['g', 'redux', 'Test'])
-  t.truthy(jetpack.exists('App/Redux/TestRedux.js'))
+  await execa(IGNITE, ['g', 'redux', 'Test'], { preferLocal: false })
+  t.is(jetpack.exists('App/Redux/TestRedux.js'), 'file')
   const lint = await execa('npm', ['run', 'lint'])
   t.is(lint.stderr, '')
 })
 
 test('generate container works', async t => {
-  await execa(IGNITE, ['g', 'container', 'Container'])
-  t.truthy(jetpack.exists('App/Containers/Container.js'))
-  t.truthy(jetpack.exists('App/Containers/Styles/ContainerStyle.js'))
+  await execa(IGNITE, ['g', 'container', 'Container'], { preferLocal: false })
+  t.is(jetpack.exists('App/Containers/Container.js'), 'file')
+  t.is(jetpack.exists('App/Containers/Styles/ContainerStyle.js'), 'file')
   const lint = await execa('npm', ['run', 'lint'])
   t.is(lint.stderr, '')
 })
 
 test('generate saga works', async t => {
-  await execa(IGNITE, ['g', 'saga', 'Test'])
-  t.truthy(jetpack.exists('App/Sagas/TestSagas.js'))
+  await execa(IGNITE, ['g', 'saga', 'Test'], { preferLocal: false })
+  t.is(jetpack.exists('App/Sagas/TestSagas.js'), 'file')
   const lint = await execa('npm', ['run', 'lint'])
   t.is(lint.stderr, '')
 })
 
 test('generate screen works', async t => {
-  await execa(IGNITE, ['g', 'screen', 'Test'])
-  t.truthy(jetpack.exists('App/Containers/TestScreen.js'))
-  t.truthy(jetpack.exists('App/Containers/Styles/TestScreenStyle.js'))
+  await execa(IGNITE, ['g', 'screen', 'Test'], { preferLocal: false })
+  t.is(jetpack.exists('App/Containers/TestScreen.js'), 'file')
+  t.is(jetpack.exists('App/Containers/Styles/TestScreenStyle.js'), 'file')
   const lint = await execa('npm', ['run', 'lint'])
   t.is(lint.stderr, '')
 })


### PR DESCRIPTION
`execa` essentially prepends `./node_modules/.bin` to the path which is causing our `exec('ignite')` to grab the `react-native` located in `./node_modules/.bin`.  

This is not the same thing as the one installed globally.   Two different version numbers.

Ignite sees this... semver fails.  Ignite exits with an error code.  ava bombs.  semaphore bombs.  my lunch plans bomb.  and the world is unhappy.

This makes the world happy again.

