### PR TITLE
Fix naming error by adding Screen to Style import on Screen template

### DIFF
--- a/templates/screen.ejs
+++ b/templates/screen.ejs
@@ -7,7 +7,7 @@ import { connect } from 'react-redux'
 // Styles
 import styles from './Styles/<%= props.name %>ScreenStyle'
 
-class <%= props.name %> extends React.Component {
+class <%= props.name %>Screen extends React.Component {
 
   render () {
     return (
@@ -31,4 +31,4 @@ const mapDispatchToProps = (dispatch) => {
   }
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(<%= props.name %>)
+export default connect(mapStateToProps, mapDispatchToProps)(<%= props.name %>Screen)

--- a/templates/screen.ejs
+++ b/templates/screen.ejs
@@ -5,7 +5,7 @@ import { connect } from 'react-redux'
 // import YourActions from '../Redux/YourRedux'
 
 // Styles
-import styles from './Styles/<%= props.name %>Style'
+import styles from './Styles/<%= props.name %>ScreenStyle'
 
 class <%= props.name %> extends React.Component {
 


### PR DESCRIPTION
When generating a `Screen`, we are naming the stylesheet as `${name}ScreenStyle` (see screenshot)
<img width="606" alt="screen shot 2017-04-23 at 1 10 35 pm" src="https://cloud.githubusercontent.com/assets/10098988/25316099/68674c98-2826-11e7-8857-32954590aa6d.png">
However, when we import the stylesheet in the Screen, we are not referencing the correct stylesheet name...
<img width="558" alt="screen shot 2017-04-23 at 1 14 13 pm" src="https://cloud.githubusercontent.com/assets/10098988/25316136/d447f35e-2826-11e7-8f04-cd3a0879297f.png">

* Fix misnaming by appending `Screen` to the stylesheet name in the template 👍 
* Append `Screen` to the screen class naming and in the `export` to be consistent with our naming
