### PR TITLE
Fix console.tron.createSagaMonitor is not a function

### DIFF
--- a/boilerplate/App/Redux/CreateStore.js
+++ b/boilerplate/App/Redux/CreateStore.js
@@ -14,7 +14,7 @@ export default (rootReducer, rootSaga) => {
 
   /* ------------- Saga Middleware ------------- */
 
-  const sagaMonitor = __DEV__ ? console.tron.createSagaMonitor() : null
+  const sagaMonitor = Config.useReactotron ? console.tron.createSagaMonitor() : null
   const sagaMiddleware = createSagaMiddleware({ sagaMonitor })
   middleware.push(sagaMiddleware)
 


### PR DESCRIPTION
Disabling reactotron in debug config leads to error `console.tron.createSagaMonitor is not a function`